### PR TITLE
Fix Dumb Invalid Time Value Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log*
 .nyc_*/
 .dir-locals.el
 .DS_Store
+.idea/

--- a/lib/core/etag.js
+++ b/lib/core/etag.js
@@ -1,7 +1,14 @@
 'use strict';
 
 module.exports = (stat, weakEtag) => {
-  let etag = `"${[stat.ino, stat.size, stat.mtime.toISOString()].join('-')}"`;
+  let time;
+  try {
+    time = stat.mtime.toISOString();
+  } catch (e) {
+    time = new Date().toISOString();
+  }
+
+  let etag = `"${[stat.ino, stat.size, time].join('-')}"`;
   if (weakEtag) {
     etag = `W/${etag}`;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "tap": "^14.11.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=12.16"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
On Linux the application would crash if the date provided by stat was invalid:

```
  let etag = `"${[stat.ino, stat.size, stat.mtime.toISOString()].join('-')}"`;
                                                  ^
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at module.exports (/home/container/.npm/_npx/1/lib/node_modules/http-server/lib/core/etag.js:4:51)
    at serve (/home/container/.npm/_npx/1/lib/node_modules/http-server/lib/core/index.js:236:20)
    at /home/container/.npm/_npx/1/lib/node_modules/http-server/lib/core/index.js:419:13
    at FSReqCallback.oncomplete (fs.js:169:5)
```